### PR TITLE
RTL support

### DIFF
--- a/lib/src/padding.dart
+++ b/lib/src/padding.dart
@@ -28,13 +28,13 @@ enum Edge {
   /// Converts the edge to an [EdgeInsetsGeometry] with the specified value.
   EdgeInsetsGeometry toEdgeInsets(double value) {
     return switch (this) {
-      Edge.all => EdgeInsets.all(value),
-      Edge.top => EdgeInsets.only(top: value),
-      Edge.bottom => EdgeInsets.only(bottom: value),
+      Edge.all => EdgeInsetsDirectional.all(value),
+      Edge.top => EdgeInsetsDirectional.only(top: value),
+      Edge.bottom => EdgeInsetsDirectional.only(bottom: value),
       Edge.leading => EdgeInsetsDirectional.only(start: value),
       Edge.trailing => EdgeInsetsDirectional.only(end: value),
-      Edge.horizontal => EdgeInsets.symmetric(horizontal: value),
-      Edge.vertical => EdgeInsets.symmetric(vertical: value),
+      Edge.horizontal => EdgeInsetsDirectional.symmetric(horizontal: value),
+      Edge.vertical => EdgeInsetsDirectional.symmetric(vertical: value),
     };
   }
 }

--- a/lib/src/padding.dart
+++ b/lib/src/padding.dart
@@ -31,8 +31,8 @@ enum Edge {
       Edge.all => EdgeInsets.all(value),
       Edge.top => EdgeInsets.only(top: value),
       Edge.bottom => EdgeInsets.only(bottom: value),
-      Edge.leading => EdgeInsets.only(left: value),
-      Edge.trailing => EdgeInsets.only(right: value),
+      Edge.leading => EdgeInsetsDirectional.only(start: value),
+      Edge.trailing => EdgeInsetsDirectional.only(end: value),
       Edge.horizontal => EdgeInsets.symmetric(horizontal: value),
       Edge.vertical => EdgeInsets.symmetric(vertical: value),
     };

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -54,7 +54,7 @@ extension WidgetXtended on Widget {
   /// Text('Hello').align(Alignment.bottomRight)
   /// ```
   ///
-  Widget align([Alignment alignment = Alignment.topLeft]) => Align(
+  Widget align([AlignmentDirectional alignment = AlignmentDirectional.topStart]) => Align(
         alignment: alignment,
         child: this,
       );


### PR DESCRIPTION
Hey! 
Thank you for bringing this interesting idea into a package.
- I noticed the implementation of the padding's toEdgeInsets function doesn't do what the docs of the `Edge` is saying for the `.trailing` and `.leading`.
- I also noticed the align function doesn't support RTL with `AlignmentDirectional`.

I think these changes are essential in the early stages to make sure developers that have to support RTL are on board (myself included). The package has to tick the supports internationalization check to match the framework.

 